### PR TITLE
Enhance dashboard inputs and inference outputs

### DIFF
--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -1,58 +1,355 @@
-import streamlit as st, json
-from inference import predict_patient
+import json
+from typing import Dict
+
+import pandas as pd
+import streamlit as st
+
+from inference import (
+    ADMISSION_TYPE_LOOKUP,
+    DEFAULT_THRESHOLDS,
+    MEDICATION_CATEGORIES,
+    MEDICATION_FIELDS,
+    predict_patient,
+)
+
 
 st.set_page_config(page_title="Healthcare Dashboard", layout="wide")
+
+RACE_OPTIONS = ["Caucasian", "AfricanAmerican", "Asian", "Hispanic", "Other"]
+GENDER_OPTIONS = ["Female", "Male"]
+AGE_OPTIONS = ["[0-10)", "[10-20)", "[20-30)", "[30-40)", "[40-50)", "[50-60)", "[60-70)", "[70-80)", "[80-90)"]
+WEIGHT_OPTIONS = [
+    "None",
+    "[0-25)",
+    "[25-50)",
+    "[50-75)",
+    "[75-100)",
+    "[100-125)",
+    "[125-150)",
+    "[150-175)",
+    "[175-200)",
+    "[>200]",
+]
+A1C_OPTIONS = ["None", "Norm", ">7", ">8"]
+GLUCOSE_OPTIONS = ["None", "Norm", ">200", ">300"]
+PAYER_OPTIONS = ["MC", "HM", "BC", "MD", "CM", "SP", "UN", "DM", "WC", "SI", "PO", "OT", "NO"]
+DISCHARGE_OPTIONS = {
+    1: "Home",
+    2: "Short-term Hospital",
+    3: "Skilled Nursing",
+    4: "Intermediate Care",
+    5: "Home Health Care",
+    6: "Against Advice",
+    7: "Home IV Provider",
+    8: "Not Available",
+    18: "Facility w/ custodial care",
+    22: "Rehab Facility",
+    23: "Long-term Hospital",
+    24: "Nursing Facility",
+    25: "Psychiatric Hospital",
+}
+ADMISSION_SOURCE_OPTIONS = {
+    1: "Physician Referral",
+    2: "Clinic Referral",
+    3: "HMO Referral",
+    4: "Transfer from Hospital",
+    5: "Transfer from SNF",
+    6: "Transfer from other Facility",
+    7: "Emergency Room",
+    8: "Court/Law Enforcement",
+    9: "Not Available",
+}
+MEDICAL_SPECIALTY_OPTIONS = [
+    "Cardiology",
+    "Endocrinology",
+    "Family/General Practice",
+    "InternalMedicine",
+    "Nephrology",
+    "Neurology",
+    "Orthopedics",
+    "Pulmonology",
+    "Surgery-General",
+]
+
+DEFAULT_PATIENT: Dict[str, object] = {
+    "race": "Caucasian",
+    "gender": "Female",
+    "age": "[60-70)",
+    "weight": "[75-100)",
+    "admission_type_id": 1,
+    "admission_type_desc": ADMISSION_TYPE_LOOKUP[1],
+    "discharge_disposition_id": 1,
+    "admission_source_id": 7,
+    "payer_code": "MC",
+    "medical_specialty": "Cardiology",
+    "num_lab_procedures": 45,
+    "num_procedures": 1,
+    "num_medications": 12,
+    "number_diagnoses": 5,
+    "number_outpatient": 0,
+    "number_emergency": 0,
+    "number_inpatient": 1,
+    "A1Cresult": "Norm",
+    "max_glu_serum": "None",
+    "diag_2": "401",
+    "diag_3": "250",
+    "diabetesMed": "Yes",
+    "metformin": "Steady",
+    "insulin": "Steady",
+}
+
+for med_field in MEDICATION_FIELDS:
+    DEFAULT_PATIENT.setdefault(med_field, "No")
+
+SAMPLE_PATIENTS: Dict[str, Dict[str, object]] = {
+    "Post-discharge follow-up": {
+        **DEFAULT_PATIENT,
+        "gender": "Male",
+        "age": "[50-60)",
+        "admission_type_id": 2,
+        "admission_type_desc": ADMISSION_TYPE_LOOKUP[2],
+        "discharge_disposition_id": 5,
+        "admission_source_id": 2,
+        "num_lab_procedures": 52,
+        "num_medications": 16,
+        "number_inpatient": 2,
+        "number_diagnoses": 7,
+        "A1Cresult": ">7",
+        "max_glu_serum": ">200",
+        "diag_2": "414",
+        "diag_3": "786",
+        "metformin": "Up",
+        "insulin": "Steady",
+        "pioglitazone": "Steady",
+    },
+    "High-utilization patient": {
+        **DEFAULT_PATIENT,
+        "age": "[70-80)",
+        "weight": "[100-125)",
+        "admission_type_id": 1,
+        "admission_type_desc": ADMISSION_TYPE_LOOKUP[1],
+        "discharge_disposition_id": 3,
+        "admission_source_id": 7,
+        "num_lab_procedures": 60,
+        "num_medications": 20,
+        "number_outpatient": 3,
+        "number_emergency": 1,
+        "number_inpatient": 4,
+        "number_diagnoses": 9,
+        "A1Cresult": ">8",
+        "max_glu_serum": ">300",
+        "diag_2": "428",
+        "diag_3": "250",
+        "insulin": "Up",
+        "rosiglitazone": "Steady",
+        "pioglitazone": "Steady",
+    },
+}
+
+if "patient_defaults" not in st.session_state:
+    st.session_state.patient_defaults = DEFAULT_PATIENT.copy()
+
 st.title("🏥 Federated Health App")
-st.caption("Multi-output predictions: readmission, LOS, med change, diagnosis group")
+st.caption("Predict readmission risk, likely length of stay, medication changes, and diagnosis grouping from structured encounter data.")
+
+with st.sidebar:
+    st.header("Configuration")
+    st.markdown("Adjust model decision thresholds and load ready-made patient profiles to explore the predictions.")
+    sample_name = st.selectbox("Patient examples", list(SAMPLE_PATIENTS.keys()), index=0)
+    if st.button("Load selected example"):
+        st.session_state.patient_defaults = SAMPLE_PATIENTS[sample_name].copy()
+        st.experimental_rerun()
+    st.divider()
+    st.subheader("Decision thresholds")
+    readm_thr = st.slider(
+        "Readmission alert threshold",
+        min_value=0.05,
+        max_value=0.95,
+        value=float(DEFAULT_THRESHOLDS["readmission"]),
+        step=0.01,
+    )
+    med_change_thr = st.slider(
+        "Medication change alert threshold",
+        min_value=0.05,
+        max_value=0.95,
+        value=float(DEFAULT_THRESHOLDS["medication_change"]),
+        step=0.01,
+    )
+    st.caption("Risk levels are categorized as Low (<34%), Moderate (34-67%), or High (>67%).")
+
+st.markdown("""
+Provide as much detail as possible about the encounter. Completing optional context such as discharge disposition or payer information helps the model avoid falling back to generic defaults, improving predictive accuracy.
+""")
+
+form_defaults = st.session_state.patient_defaults
 
 with st.form("patient_form"):
-    st.subheader("Patient Input")
-    col1, col2, col3 = st.columns(3)
-    with col1:
-        race  = st.selectbox("Race", ["Caucasian","AfricanAmerican","Asian","Hispanic","Other"])
-        gender= st.selectbox("Gender", ["Male","Female"])
-        age   = st.selectbox("Age Range", ["[30-40)","[40-50)","[50-60)","[60-70)","[70-80)","[80-90)"])
-        medical_specialty = st.text_input("Medical Specialty", value="Cardiology")
-    with col2:
-        num_lab_procedures = st.number_input("Lab procedures", 0, 100, 45)
-        num_procedures     = st.number_input("Procedures", 0, 10, 1)
-        num_medications    = st.number_input("Medications", 0, 50, 12)
-        number_diagnoses   = st.number_input("Number of diagnoses", 0, 20, 5)
-    with col3:
-        number_outpatient  = st.number_input("Outpatient visits", 0, 30, 0)
-        number_emergency   = st.number_input("Emergency visits", 0, 30, 0)
-        number_inpatient   = st.number_input("Inpatient visits", 0, 30, 1)
-        admission_type_id  = st.number_input("Admission type id", 1, 8, 1)
-    a1c  = st.selectbox("A1C result", ["Norm",">7",">8","None"])
-    glu  = st.selectbox("Max glucose serum", ["None",">200",">300","Norm"])
-    diag_2 = st.text_input("Diagnosis code 2", value="401")
-    diag_3 = st.text_input("Diagnosis code 3", value="250")
-    metformin = st.selectbox("Metformin", ["No","Steady","Up","Down"])
-    insulin   = st.selectbox("Insulin",   ["No","Steady","Up","Down"])
-    diabetesMed = st.selectbox("On diabetes medication?", ["Yes","No"])
-    submitted = st.form_submit_button("Predict")
+    st.subheader("Patient profile")
+    demo_col1, demo_col2, demo_col3 = st.columns(3)
+    with demo_col1:
+        race = st.selectbox("Race", RACE_OPTIONS, index=RACE_OPTIONS.index(form_defaults.get("race", RACE_OPTIONS[0])))
+        gender = st.selectbox("Gender", GENDER_OPTIONS, index=GENDER_OPTIONS.index(form_defaults.get("gender", GENDER_OPTIONS[0])))
+        age = st.selectbox("Age band", AGE_OPTIONS, index=AGE_OPTIONS.index(form_defaults.get("age", AGE_OPTIONS[0])))
+    with demo_col2:
+        weight = st.selectbox("Weight band", WEIGHT_OPTIONS, index=WEIGHT_OPTIONS.index(form_defaults.get("weight", WEIGHT_OPTIONS[0])), help="Weight from most recent inpatient stay (if coded).")
+        payer_code = st.selectbox("Primary payer", PAYER_OPTIONS, index=PAYER_OPTIONS.index(form_defaults.get("payer_code", PAYER_OPTIONS[0])))
+        medical_specialty = st.selectbox("Admitting specialty", MEDICAL_SPECIALTY_OPTIONS, index=MEDICAL_SPECIALTY_OPTIONS.index(form_defaults.get("medical_specialty", MEDICAL_SPECIALTY_OPTIONS[0])))
+    with demo_col3:
+        admission_type_id = st.selectbox(
+            "Admission type",
+            options=list(ADMISSION_TYPE_LOOKUP.keys()),
+            format_func=lambda x: f"{x} – {ADMISSION_TYPE_LOOKUP[x]}",
+            index=list(ADMISSION_TYPE_LOOKUP.keys()).index(int(form_defaults.get("admission_type_id", 1))),
+        )
+        discharge_disposition_id = st.selectbox(
+            "Discharge disposition",
+            options=list(DISCHARGE_OPTIONS.keys()),
+            format_func=lambda x: f"{x} – {DISCHARGE_OPTIONS[x]}",
+            index=list(DISCHARGE_OPTIONS.keys()).index(int(form_defaults.get("discharge_disposition_id", 1))),
+        )
+        admission_source_id = st.selectbox(
+            "Admission source",
+            options=list(ADMISSION_SOURCE_OPTIONS.keys()),
+            format_func=lambda x: f"{x} – {ADMISSION_SOURCE_OPTIONS[x]}",
+            index=list(ADMISSION_SOURCE_OPTIONS.keys()).index(int(form_defaults.get("admission_source_id", 7))),
+        )
+
+    st.markdown("---")
+    st.subheader("Utilization & labs")
+    util_col1, util_col2, util_col3 = st.columns(3)
+    with util_col1:
+        num_lab_procedures = st.number_input("Lab procedures", min_value=0, max_value=120, value=int(form_defaults.get("num_lab_procedures", 40)))
+        num_procedures = st.number_input("Procedures", min_value=0, max_value=10, value=int(form_defaults.get("num_procedures", 1)))
+        num_medications = st.number_input("Medications", min_value=0, max_value=60, value=int(form_defaults.get("num_medications", 10)))
+    with util_col2:
+        number_outpatient = st.number_input("Outpatient visits (past year)", min_value=0, max_value=50, value=int(form_defaults.get("number_outpatient", 0)))
+        number_emergency = st.number_input("Emergency visits (past year)", min_value=0, max_value=50, value=int(form_defaults.get("number_emergency", 0)))
+        number_inpatient = st.number_input("Inpatient stays (past year)", min_value=0, max_value=50, value=int(form_defaults.get("number_inpatient", 1)))
+    with util_col3:
+        number_diagnoses = st.number_input("Unique diagnoses this stay", min_value=0, max_value=20, value=int(form_defaults.get("number_diagnoses", 5)))
+        a1c = st.selectbox("A1C result", A1C_OPTIONS, index=A1C_OPTIONS.index(form_defaults.get("A1Cresult", A1C_OPTIONS[0])), help="Most recent A1C in the medical record.")
+        glu = st.selectbox("Max glucose serum", GLUCOSE_OPTIONS, index=GLUCOSE_OPTIONS.index(form_defaults.get("max_glu_serum", GLUCOSE_OPTIONS[0])), help="Highest glucose serum measurement recorded.")
+
+    diag_col1, diag_col2 = st.columns(2)
+    with diag_col1:
+        diag_2 = st.text_input("Secondary diagnosis code", value=str(form_defaults.get("diag_2", "UNK")), help="Use ICD-9 style codes (e.g., 401 for hypertension).").strip().upper()
+    with diag_col2:
+        diag_3 = st.text_input("Tertiary diagnosis code", value=str(form_defaults.get("diag_3", "UNK")), help="Use ICD-9 style codes (e.g., 250 for diabetes).").strip().upper()
+
+    with st.expander("Medication orders", expanded=False):
+        med_columns = st.columns(3)
+        meds_collections = [
+            MEDICATION_FIELDS[i::3] for i in range(3)
+        ]
+        med_values: Dict[str, str] = {}
+        for column, fields in zip(med_columns, meds_collections):
+            with column:
+                for med_field in fields:
+                    default_val = form_defaults.get(med_field, "No")
+                    med_values[med_field] = st.selectbox(
+                        med_field.replace("-", " → ").title(),
+                        MEDICATION_CATEGORIES,
+                        index=MEDICATION_CATEGORIES.index(default_val if default_val in MEDICATION_CATEGORIES else "No"),
+                        help="Order status during this admission.",
+                        key=f"med_{med_field}",
+                    )
+
+    diabetes_med = st.selectbox(
+        "Patient on any diabetes medications?",
+        ["Yes", "No"],
+        index=["Yes", "No"].index(form_defaults.get("diabetesMed", "Yes")),
+    )
+
+    submitted = st.form_submit_button("Run prediction", use_container_width=True)
+
+patient_inputs = {
+    "race": race,
+    "gender": gender,
+    "age": age,
+    "weight": weight,
+    "payer_code": payer_code,
+    "medical_specialty": medical_specialty,
+    "admission_type_id": admission_type_id,
+    "admission_type_desc": ADMISSION_TYPE_LOOKUP.get(admission_type_id),
+    "discharge_disposition_id": discharge_disposition_id,
+    "admission_source_id": admission_source_id,
+    "num_lab_procedures": num_lab_procedures,
+    "num_procedures": num_procedures,
+    "num_medications": num_medications,
+    "number_diagnoses": number_diagnoses,
+    "number_outpatient": number_outpatient,
+    "number_emergency": number_emergency,
+    "number_inpatient": number_inpatient,
+    "A1Cresult": a1c,
+    "max_glu_serum": glu,
+    "diag_2": diag_2,
+    "diag_3": diag_3,
+    "diabetesMed": diabetes_med,
+}
+patient_inputs.update(med_values if "med_values" in locals() else {})
 
 if submitted:
-    patient = {
-        "race": race, "gender": gender, "age": age, "medical_specialty": medical_specialty,
-        "num_lab_procedures": num_lab_procedures, "num_procedures": num_procedures,
-        "num_medications": num_medications, "number_diagnoses": number_diagnoses,
-        "number_outpatient": number_outpatient, "number_emergency": number_emergency,
-        "number_inpatient": number_inpatient, "admission_type_id": admission_type_id,
-        "A1Cresult": a1c, "max_glu_serum": glu, "diag_2": diag_2, "diag_3": diag_3,
-        "metformin": metformin, "insulin": insulin, "diabetesMed": diabetesMed,
+    st.session_state.patient_defaults = patient_inputs.copy()
+    thresholds = {
+        "readmission": readm_thr,
+        "medication_change": med_change_thr,
     }
-    results = predict_patient(patient, thr=0.5)
-    st.subheader("Results")
-    c1, c2 = st.columns(2)
-    with c1:
-        st.metric("Readmission (<30d)", results["Readmission (<30d)"]["Prediction"],
-                  f'{results["Readmission (<30d)"]["Probability"]}%')
-        st.metric("Medication Change", results["Medication Change"]["Prediction"],
-                  f'{results["Medication Change"]["Probability"]}%')
-    with c2:
-        st.metric("Length of Stay", results["Length of Stay"]["Prediction"],
-                  f'{results["Length of Stay"]["Probability"]}%')
-        st.metric("Diagnosis Group", results["Diagnosis Group"]["Prediction"],
-                  f'{results["Diagnosis Group"]["Probability"]}%')
-    st.code(json.dumps(results, indent=2), language="json")
+    with st.spinner("Scoring patient across all tasks..."):
+        results = predict_patient(
+            patient_inputs,
+            thresholds=thresholds,
+            include_distributions=True,
+            top_k=3,
+        )
+
+    st.subheader("Prediction summary")
+
+    def render_binary_card(title: str, info: Dict[str, object]):
+        prob = float(info.get("Probability", 0.0))
+        probability_pct = f"{prob:.1f}%"
+        risk = info.get("Risk", "Unknown")
+        risk_emoji = {"Low": "🟢", "Moderate": "🟠", "High": "🔴"}.get(risk, "⚪")
+        threshold = float(info.get("Threshold", 0.5))
+        st.markdown(f"#### {title}")
+        st.metric("Prediction", info.get("Prediction", "N/A"), probability_pct)
+        st.progress(min(max(prob / 100.0, 0.0), 1.0))
+        st.caption(f"{risk_emoji} Risk level: **{risk}** • Alert threshold: {threshold:.2f}")
+
+    col_left, col_right = st.columns(2)
+    with col_left:
+        render_binary_card("Readmission within 30 days", results["Readmission (<30d)"])
+        render_binary_card("Medication regimen change", results["Medication Change"])
+    with col_right:
+        los_info = results["Length of Stay"]
+        st.markdown("#### Length of stay")
+        st.metric("Most likely band", los_info.get("Prediction", "N/A"), f"{los_info.get('Probability', 0):.1f}% confidence")
+        st.progress(min(max(float(los_info.get("Probability", 0)) / 100.0, 0.0), 1.0))
+        top_los_df = pd.DataFrame(los_info.get("Top Alternatives", [])).rename(columns={"Label": "Length of stay", "Probability": "Probability (%)"})
+        if not top_los_df.empty:
+            st.dataframe(top_los_df, hide_index=True, use_container_width=True)
+
+        diag_info = results["Diagnosis Group"]
+        st.markdown("#### Diagnosis grouping")
+        st.metric("Most likely group", diag_info.get("Prediction", "N/A"), f"{diag_info.get('Probability', 0):.1f}% confidence")
+        diag_df = pd.DataFrame(diag_info.get("Top Alternatives", [])).rename(columns={"Label": "Group", "Probability": "Probability (%)"})
+        if not diag_df.empty:
+            st.dataframe(diag_df, hide_index=True, use_container_width=True)
+
+    st.markdown("---")
+    st.subheader("Detailed outputs")
+    tabs = st.tabs(["Distributions", "Raw JSON"])
+    with tabs[0]:
+        distributions = results.get("_distributions", {})
+        if distributions:
+            los_dist = distributions.get("length_of_stay", {})
+            if los_dist:
+                st.markdown("**Length of stay probabilities**")
+                st.bar_chart(pd.Series(los_dist))
+            diag_dist = distributions.get("diagnosis_group", {})
+            if diag_dist:
+                st.markdown("**Diagnosis group probabilities**")
+                st.bar_chart(pd.Series(diag_dist))
+        else:
+            st.info("Distribution details not available for this model.")
+    with tabs[1]:
+        st.code(json.dumps(results, indent=2), language="json")

--- a/app/inference.py
+++ b/app/inference.py
@@ -1,7 +1,63 @@
-import os, json, cloudpickle, numpy as np, pandas as pd
+import os
+import json
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import cloudpickle
+import numpy as np
+import pandas as pd
 
 BASE_DIR   = os.path.dirname(os.path.dirname(__file__))
 MODELS_DIR = os.path.join(BASE_DIR, "models")
+
+DEFAULT_THRESHOLDS = {
+    "readmission": 0.5,
+    "medication_change": 0.5,
+}
+
+RISK_BANDS: Tuple[Tuple[float, float, str], ...] = (
+    (0.0, 0.34, "Low"),
+    (0.34, 0.67, "Moderate"),
+    (0.67, 1.01, "High"),  # upper bound slightly >1 to capture rounding artefacts
+)
+
+ADMISSION_TYPE_LOOKUP = {
+    1: "Emergency",
+    2: "Urgent",
+    3: "Elective",
+    4: "Newborn",
+    5: "Not Available",
+    6: "NULL",
+    7: "Trauma Center",
+    8: "Not Mapped",
+}
+
+MEDICATION_FIELDS: Tuple[str, ...] = (
+    "metformin",
+    "repaglinide",
+    "nateglinide",
+    "chlorpropamide",
+    "glimepiride",
+    "acetohexamide",
+    "glipizide",
+    "glyburide",
+    "tolbutamide",
+    "pioglitazone",
+    "rosiglitazone",
+    "acarbose",
+    "miglitol",
+    "troglitazone",
+    "tolazamide",
+    "examide",
+    "citoglipton",
+    "insulin",
+    "glyburide-metformin",
+    "glipizide-metformin",
+    "glimepiride-pioglitazone",
+    "metformin-rosiglitazone",
+    "metformin-pioglitazone",
+)
+
+MEDICATION_CATEGORIES = ("No", "Steady", "Up", "Down")
 
 def diag_group_first_char(x):
     x = str(x)
@@ -9,7 +65,35 @@ def diag_group_first_char(x):
     ch = x[0].upper()
     return ch if ch in list("0123456789VE") else "UNK"
 
-def preprocess_patient_input(raw: dict, feature_order, num_cols, cat_cols, train_medians=None):
+def clean_diag_code(code: object) -> str:
+    if code is None:
+        return "UNK"
+    code_str = str(code).strip().upper()
+    return code_str if code_str else "UNK"
+
+
+def fill_admission_description(values: Dict[str, object]) -> None:
+    if values.get("admission_type_desc"):
+        return
+    try:
+        admission_id = int(values.get("admission_type_id"))
+    except (TypeError, ValueError):
+        admission_id = None
+    if admission_id in ADMISSION_TYPE_LOOKUP:
+        values["admission_type_desc"] = ADMISSION_TYPE_LOOKUP[admission_id]
+
+
+def preprocess_patient_input(
+    raw: Dict[str, object],
+    feature_order: Iterable[str],
+    num_cols: Iterable[str],
+    cat_cols: Iterable[str],
+    train_medians: Optional[Dict[str, float]] = None,
+):
+    raw = dict(raw)
+    fill_admission_description(raw)
+    raw["diag_2"] = clean_diag_code(raw.get("diag_2"))
+    raw["diag_3"] = clean_diag_code(raw.get("diag_3"))
     dfp = pd.DataFrame([raw]).copy()
     for c in ["number_outpatient","number_emergency","number_inpatient"]:
         if c not in dfp: dfp[c] = 0
@@ -22,10 +106,15 @@ def preprocess_patient_input(raw: dict, feature_order, num_cols, cat_cols, train
     dfp["diag_3_group"] = dfp.get("diag_3", "UNK").apply(diag_group_first_char)
     for c in feature_order:
         if c not in dfp.columns:
-            dfp[c] = 0 if c in num_cols else "__MISSING__"
+            default_value = 0 if c in num_cols else "__MISSING__"
+            dfp[c] = default_value
+    if train_medians:
+        numeric_fill_values = {c: train_medians.get(c, 0) for c in num_cols}
+    else:
+        numeric_fill_values = {c: 0 for c in num_cols}
     dfp = dfp[feature_order]
     for c in num_cols:
-        dfp[c] = pd.to_numeric(dfp[c], errors="coerce").fillna(0)
+        dfp[c] = pd.to_numeric(dfp[c], errors="coerce").fillna(numeric_fill_values[c])
     for c in cat_cols:
         dfp[c] = dfp[c].astype("string").fillna("__MISSING__")
     return dfp
@@ -40,23 +129,129 @@ def load_artifacts():
     feature_order = num_cols + cat_cols
     los_classes = meta.get("los_classes", ["short","medium","long"])
     diag_map = meta.get("diaggrp_mapping", {})
-    return pipe, feature_order, num_cols, cat_cols, los_classes, diag_map
+    inv_diag_map = {int(v): k for k, v in diag_map.items()}
+    diag_pretty_labels = {
+        "1": "Circulatory",
+        "2": "Respiratory",
+        "3": "Digestive",
+        "4": "Diabetes/Endocrine",
+        "5": "Injury/Poisoning",
+        "6": "Musculoskeletal",
+        "7": "Genitourinary",
+        "8": "Neoplasms",
+        "9": "Other",
+        "E": "External Causes",
+        "V": "Supplementary",
+        "UNK": "Unknown",
+    }
+    medians_path = os.path.join(MODELS_DIR, "feature_medians.json")
+    train_medians = None
+    if os.path.exists(medians_path):
+        with open(medians_path, "r") as f:
+            train_medians = json.load(f)
+    return (
+        pipe,
+        feature_order,
+        num_cols,
+        cat_cols,
+        los_classes,
+        inv_diag_map,
+        diag_pretty_labels,
+        train_medians,
+    )
 
-pipe, FEATURE_ORDER, NUM_COLS, CAT_COLS, LOS_CLASSES, DIAG_MAP = load_artifacts()
+(
+    pipe,
+    FEATURE_ORDER,
+    NUM_COLS,
+    CAT_COLS,
+    LOS_CLASSES,
+    DIAG_MAP_INV,
+    DIAGNOSIS_GROUP_NAMES,
+    TRAIN_NUMERIC_MEDIANS,
+) = load_artifacts()
 
-def predict_patient(patient_dict, thr=0.5):
-    dfp = preprocess_patient_input(patient_dict, FEATURE_ORDER, NUM_COLS, CAT_COLS)
+def _risk_bucket(prob: float) -> str:
+    for lower, upper, label in RISK_BANDS:
+        if lower <= prob < upper:
+            return label
+    return RISK_BANDS[-1][2]
+
+
+def _top_k_labels(probs: np.ndarray, labels: Sequence, k: int = 3) -> List[Tuple[object, float]]:
+    k = min(k, len(labels))
+    top_indices = np.argsort(probs)[::-1][:k]
+    return [(labels[idx], float(probs[idx])) for idx in top_indices]
+
+
+def predict_patient(
+    patient_dict: Dict[str, object],
+    thr: float = 0.5,
+    thresholds: Optional[Dict[str, float]] = None,
+    include_distributions: bool = True,
+    top_k: int = 3,
+):
+    thresholds = thresholds or {}
+    thr_readm = thresholds.get("readmission", thresholds.get("readmission_risk", thr))
+    thr_med_change = thresholds.get("medication_change", thr)
+    dfp = preprocess_patient_input(
+        patient_dict,
+        FEATURE_ORDER,
+        NUM_COLS,
+        CAT_COLS,
+        train_medians=TRAIN_NUMERIC_MEDIANS,
+    )
     all_probs = pipe.predict_proba(dfp)
     results = {}
     pr = float(all_probs[0][:,1][0])
-    results["Readmission (<30d)"] = {"Prediction": "Yes" if pr>=thr else "No", "Probability": round(pr*100,2)}
+    readmission_pred = "Yes" if pr >= thr_readm else "No"
+    results["Readmission (<30d)"] = {
+        "Prediction": readmission_pred,
+        "Probability": round(pr * 100, 2),
+        "Risk": _risk_bucket(pr),
+        "Threshold": thr_readm,
+    }
     los_vec = all_probs[1][0]
     los_idx = int(np.argmax(los_vec))
-    results["Length of Stay"] = {"Prediction": LOS_CLASSES[los_idx], "Probability": round(float(np.max(los_vec))*100,2)}
+    los_prediction = LOS_CLASSES[los_idx]
+    results["Length of Stay"] = {
+        "Prediction": los_prediction,
+        "Probability": round(float(np.max(los_vec)) * 100, 2),
+        "Top Alternatives": [
+            {"Label": label, "Probability": round(prob * 100, 2)}
+            for label, prob in _top_k_labels(los_vec, LOS_CLASSES, k=top_k)
+        ],
+    }
     pm = float(all_probs[2][:,1][0])
-    results["Medication Change"] = {"Prediction": "Yes" if pm>=thr else "No", "Probability": round(pm*100,2)}
+    med_change_pred = "Yes" if pm >= thr_med_change else "No"
+    results["Medication Change"] = {
+        "Prediction": med_change_pred,
+        "Probability": round(pm * 100, 2),
+        "Risk": _risk_bucket(pm),
+        "Threshold": thr_med_change,
+    }
     dg_vec = all_probs[3][0]
     dg_idx = int(np.argmax(dg_vec))
-    inv = {v:k for k,v in DIAG_MAP.items()}
-    results["Diagnosis Group"] = {"Prediction": inv.get(dg_idx, str(dg_idx)), "Probability": round(float(np.max(dg_vec))*100,2)}
+    diag_code = DIAG_MAP_INV.get(dg_idx, str(dg_idx))
+    diag_name = DIAGNOSIS_GROUP_NAMES.get(diag_code, diag_code)
+    top_diag = _top_k_labels(dg_vec, list(range(len(dg_vec))), k=top_k)
+    results["Diagnosis Group"] = {
+        "Prediction": f"{diag_name} ({diag_code})",
+        "Probability": round(float(np.max(dg_vec)) * 100, 2),
+        "Top Alternatives": [
+            {
+                "Label": f"{DIAGNOSIS_GROUP_NAMES.get(DIAG_MAP_INV.get(int(idx), str(idx)), DIAG_MAP_INV.get(int(idx), str(idx)))} ({DIAG_MAP_INV.get(int(idx), str(idx))})",
+                "Probability": round(prob * 100, 2),
+            }
+            for idx, prob in top_diag
+        ],
+    }
+    if include_distributions:
+        results["_distributions"] = {
+            "length_of_stay": {label: float(prob) for label, prob in zip(LOS_CLASSES, los_vec)},
+            "diagnosis_group": {
+                DIAGNOSIS_GROUP_NAMES.get(DIAG_MAP_INV.get(idx, str(idx)), DIAG_MAP_INV.get(idx, str(idx))): float(prob)
+                for idx, prob in enumerate(dg_vec)
+            },
+        }
     return results


### PR DESCRIPTION
## Summary
- extend inference preprocessing with admission descriptions, diagnosis cleaning, optional median fills, and richer probability outputs for downstream use
- redesign the Streamlit dashboard with comprehensive patient inputs, example profiles, adjustable thresholds, and clearer result visualisations
- surface top alternative classes and probability distributions to help clinicians interpret each prediction

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d51745b4c8832aa45496e149778aa6