### PR TITLE
Switch training to Random Forest and add Windows guide

### DIFF
--- a/WINDOWS_VSCODE_GUIDE.txt
+++ b/WINDOWS_VSCODE_GUIDE.txt
@@ -1,0 +1,73 @@
+Windows + VS Code quickstart
+============================
+
+Prerequisites
+-------------
+1. Install **Python 3.11** from https://www.python.org/downloads/windows/ (tick "Add python.exe to PATH").
+2. Install **Git for Windows** from https://git-scm.com/download/win.
+3. Install **VS Code** from https://code.visualstudio.com/ and add the "Python" + "GitHub Copilot" (optional) extensions.
+4. Place the dataset CSVs you mentioned in an easy-to-find folder, e.g. leave them at:
+   * `C:\Users\user\Downloads\IDS_mapping.csv`
+   * `C:\Users\user\Downloads\diabetic_data.csv`
+
+Clone & open the repo
+---------------------
+1. Open **Command Prompt** and run:
+   ```bat
+   cd %USERPROFILE%\Documents
+   git clone https://github.com/<your-org>/federated_health_app.git
+   cd federated_health_app
+   ```
+2. Launch VS Code pointing to this folder:
+   ```bat
+   code .
+   ```
+3. When prompted in VS Code, create a Python virtual environment (or run `python -m venv .venv` then ` .venv\Scripts\activate`).
+
+Install dependencies
+--------------------
+```bat
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+Run the Streamlit app locally
+-----------------------------
+1. In VS Code, open a new terminal (``Ctrl+` ``).
+2. Activate the virtual environment if it is not active:
+   ```bat
+   .venv\Scripts\activate
+   ```
+3. Start the dashboard:
+   ```bat
+   streamlit run app/Home.py
+   ```
+4. Open the browser tab that Streamlit prints (usually http://localhost:8501).
+
+Train the Random-Forest model on Windows
+---------------------------------------
+1. Ensure the CSVs live where the training script can see them. If they are still in Downloads, pass the absolute paths when training.
+2. From the repo root in the activated virtual environment, run:
+   ```bat
+   python -m training.train_pipeline ^
+       --input "C:\Users\user\Downloads\diabetic_data.csv" ^
+       --output models\rf_run ^
+       --readmission-target readmitted_30d ^
+       --los-target length_of_stay ^
+       --medication-target medication_change ^
+       --diagnosis-target diagnosis_group
+   ```
+   * Adjust the target column names if your CSV headers differ.
+   * The script automatically saves `multi_pipeline.pkl`, `feature_medians.json`, and `meta.json` under the `models\rf_run` folder.
+3. (Optional) If you need to merge `IDS_mapping.csv` to enrich categorical descriptions before training, prepare a new CSV with that merge logic in pandas, then feed the resulting file as `--input`.
+
+Use the trained artefacts inside VS Code
+----------------------------------------
+1. Copy the generated files in `models\rf_run` into the app's `models` folder if you want the Streamlit app to pick them up by default.
+2. Restart the Streamlit app (``Ctrl+C`` then re-run the command above). The UI will now load your Random-Forest pipeline.
+
+Troubleshooting tips
+--------------------
+* If VS Code cannot find Python, set the interpreter via `Ctrl+Shift+P -> Python: Select Interpreter -> .venv`.
+* Long file paths on Windows may need quoting (`"C:\\Users\\user\\Downloads\\diabetic_data.csv"`).
+* When training on large CSVs, consider running `python -m training.train_pipeline --help` to see additional flags such as `--test-size` and `--random-state`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 streamlit
 cloudpickle
 scikit-learn==1.6.1
-lightgbm==4.5.0
 pandas==2.2.3
 numpy==2.1.2
 joblib==1.4.2

--- a/training/train_pipeline.py
+++ b/training/train_pipeline.py
@@ -1,7 +1,7 @@
 """Command line utility to (re)train the healthcare multi-task model.
 
 The script expects a tabular dataset with the same feature space that the
-Streamlit application collects from users.  It performs LightGBM-based
+Streamlit application collects from users.  It performs Random Forest-based
 multi-task classification, evaluates the hold-out performance, performs a
 light-weight search for discriminative thresholds and persists the artefacts in
 ``models/`` so that the dashboard can immediately consume the refreshed model.
@@ -17,7 +17,7 @@ from typing import Dict, List, Mapping, Sequence, Tuple
 
 import numpy as np
 import pandas as pd
-from lightgbm import LGBMClassifier
+from sklearn.ensemble import RandomForestClassifier
 from sklearn.compose import ColumnTransformer
 from sklearn.metrics import accuracy_score, f1_score, roc_auc_score
 from sklearn.model_selection import train_test_split
@@ -193,18 +193,16 @@ def _build_pipeline() -> Pipeline:
             ),
         ]
     )
-    base_estimator = LGBMClassifier(
-        n_estimators=900,
-        learning_rate=0.03,
-        num_leaves=63,
-        min_child_samples=30,
-        subsample=0.8,
-        colsample_bytree=0.7,
-        reg_lambda=1.0,
-        reg_alpha=0.1,
-        class_weight="balanced",
-        random_state=42,
+    base_estimator = RandomForestClassifier(
+        n_estimators=600,
+        max_depth=None,
+        min_samples_split=6,
+        min_samples_leaf=5,
+        max_features="sqrt",
+        class_weight="balanced_subsample",
+        bootstrap=True,
         n_jobs=-1,
+        random_state=42,
     )
     classifier = MultiOutputClassifier(base_estimator, n_jobs=-1)
     return Pipeline([("pre", preprocessor), ("clf", classifier)])
@@ -238,9 +236,11 @@ def _evaluate_model(pipe: Pipeline, X_val: pd.DataFrame, y_val: EncodedTargets) 
     return metrics
 
 
-def _save_feature_medians(X_train: pd.DataFrame) -> None:
+def _save_feature_medians(X_train: pd.DataFrame, output_dir: str) -> None:
+    """Persist per-feature medians for numeric imputation during inference."""
+
     medians = X_train[list(NUMERIC_FEATURES)].median().to_dict()
-    with open(os.path.join(MODELS_DIR, "feature_medians.json"), "w") as f:
+    with open(os.path.join(output_dir, "feature_medians.json"), "w") as f:
         json.dump(medians, f, indent=2)
 
 
@@ -250,6 +250,7 @@ def _save_meta(
     diag_mapping: Mapping[str, int],
     metrics: Mapping[str, float],
     thresholds: Mapping[str, float],
+    output_dir: str,
 ) -> None:
     meta = {
         "timestamp": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
@@ -262,7 +263,7 @@ def _save_meta(
         "metrics": metrics,
         "optimal_thresholds": thresholds,
     }
-    with open(os.path.join(MODELS_DIR, "meta.json"), "w") as f:
+    with open(os.path.join(output_dir, "meta.json"), "w") as f:
         json.dump(meta, f, indent=2)
 
 
@@ -350,13 +351,14 @@ def main() -> None:
 
         cloudpickle.dump(pipeline, f)
 
-    _save_feature_medians(X_train)
+    _save_feature_medians(X_train, args.output)
     _save_meta(
         features={"num": NUMERIC_FEATURES, "cat": CATEGORICAL_FEATURES},
         los_classes=targets.los_classes,
         diag_mapping=targets.diagnosis_mapping,
         metrics={k: float(v) for k, v in metrics.items()},
         thresholds=optimal_thresholds,
+        output_dir=args.output,
     )
 
     report_lines = [


### PR DESCRIPTION
## Summary
- replace the LightGBM base estimator with a tuned Random Forest inside the multi-output pipeline and update the module documentation accordingly
- drop the unused LightGBM dependency from `requirements.txt`
- add a step-by-step Windows + VS Code guide that explains how to install dependencies, run the dashboard, and train on the provided CSV paths

## Testing
- `pytest`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b1ddeb8f0832abebf4ce0c5374d25)